### PR TITLE
handle-click export

### DIFF
--- a/dev/modules/handle-click.js
+++ b/dev/modules/handle-click.js
@@ -121,7 +121,7 @@ var handleCancel = function(modal, params) {
 };
 
 
-export default {
+export {
   handleButton,
   handleConfirm,
   handleCancel


### PR DESCRIPTION
should export default only one module.